### PR TITLE
Fix Outland flyable detection

### DIFF
--- a/Squire3.lua
+++ b/Squire3.lua
@@ -94,8 +94,12 @@ local function IsReallyFlyable(continent)
 	elseif continent == 6 then
 		-- Pandaria requires Wisdom of the Four Winds
 		return IsPlayerSpell(115913)
+	elseif continent == 3 then
+		-- Outland requires Expert Riding or above
+		return IsPlayerSpell(90265)	-- Master
+			or IsPlayerSpell(34091)	-- Artisan
+			or IsPlayerSpell(34090)	-- Expert
 	end
-	-- Outland (#3) requires the flying skill (and is hopefully handled by IsUsableSpell)
 	-- Draenor (#7) is not flyable yet
 	return false
 end


### PR DESCRIPTION
Outland requires Expert Riding or above to fly.
Unfortunately, we can't just test for Expert, as it's not known
if a higher riding skill is.
Check for Master, Artisan or Expert riding in that order, given
the common case is most likely fully skilled players.
